### PR TITLE
Add 'Exception' to the except clause in __getitem__() of the Prefs class

### DIFF
--- a/pyatom/Prefs.py
+++ b/pyatom/Prefs.py
@@ -69,11 +69,7 @@ class Prefs(UserDict):
         return self.__getitem__(key)
 
     def __getitem__(self, key):
-        result = None
-        try:
-            result = self.data.get(key, None)
-        except Exception:
-            pass
+        result = self.data.get(key, None)
         if result is None or result == '':
             if self.defaults:
                 result = self.defaults.get(key, None)


### PR DESCRIPTION
Added 'Exception' to the except clause in **getitem**() of the Prefs class to
provide a bit more specificity to exceptions clause.  A potential future change
may include narrowing the expected exceptions to catch.
