### PR TITLE
Request to add getFrontmostApp to Atomac API

### DIFF
--- a/atomac/AXClasses.py
+++ b/atomac/AXClasses.py
@@ -84,6 +84,29 @@ class BaseAXUIElement(_a11y.AXUIElement):
       raise ValueError('Specified application not found in running apps.')
 
    @classmethod
+   def getFrontmostApp(cls):
+      '''getFrontmostApp - Get the current frontmost application'''
+      # Refresh the runningApplications list
+      def runLoopAndExit():
+         AppHelper.stopEventLoop()
+      AppHelper.callLater(1, runLoopAndExit)
+      AppHelper.runConsoleEventLoop()
+      # Get a list of running applications
+      ws = AppKit.NSWorkspace.sharedWorkspace()
+      apps = ws.runningApplications()
+      for app in apps:
+         pid = app.processIdentifier()
+         ref = cls.getAppRefByPid(pid)
+         try:
+            if ref.AXFrontmost:
+               return ref
+         except (_a11y.ErrorUnsupported, _a11y.ErrorCannotComplete):
+            # Some applications do not have an explicit GUI
+            # and so will not have an AXFrontmost attribute
+            pass
+      raise ValueError('No application found to be frontmost - error?')
+
+   @classmethod
    def getSystemObject(cls):
       '''getSystemObject - Get the top level system accessibility object'''
       return _a11y.getSystemObject(cls)

--- a/atomac/__init__.py
+++ b/atomac/__init__.py
@@ -30,3 +30,4 @@ setSystemWideTimeout = NativeUIElement.setSystemWideTimeout
 getAppRefByBundleId = NativeUIElement.getAppRefByBundleId
 launchAppByBundleId = NativeUIElement.launchAppByBundleId
 getAppRefByPid = NativeUIElement.getAppRefByPid
+getFrontmostApp = NativeUIElement.getFrontmostApp


### PR DESCRIPTION
Notes:

New API call added at suggestion of a user.  Question as to whether it even makes sense to add such an API call?

TODOs:

Exception message can be improved.
Refactoring should probably be done prior to pull?

Original commit message:

Add a class method to get the current frontmost app
at the suggestion of a user.  This allows a user
to find what the current frontmost app is.

Current implementation is essentially a copy of
getAppRefByLocalizedName(), so some refactoring
would be in order.

Testing done:

> > > import atomac
> > > sys.path.insert(0,
> > > ... '/Users/awu/Documents/projects/pyatom/build/lib.macosx-10.6-universal-2.6/atomac')
> > > sys.path.pop(7)
> > > '/Library/Python/2.6/site-packages/atomac-0.9.3-py2.6-macosx-10.6-universal.egg'
> > > 
> > > atomac.getFrontmostApp()
> > > <atomac.AXClasses.NativeUIElement AXApplication u'Terminal'>
> > > 
> > > time.sleep(1); atomac.getFrontmostApp()
> > > <atomac.AXClasses.NativeUIElement AXApplication u'Safari'>
