### PR TITLE
Add the import of ErrorUnsupported from _a11y so that we can actualy cat...

### DIFF
--- a/atomac/__init__.py
+++ b/atomac/__init__.py
@@ -16,7 +16,7 @@
 # St, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from _a11y import Error, ErrorAPIDisabled, ErrorInvalidUIElement
-from _a11y import ErrorCannotComplete
+from _a11y import ErrorCannotComplete, ErrorUnsupported
 from AXClasses import NativeUIElement
 from Clipboard import Clipboard
 from version import __version__


### PR DESCRIPTION
...ch it with python falling over
