### PR TITLE
Replace UTF-8 symbol in comment with its ASCII equivalent

### DIFF
--- a/atomac/ldtpd/utils.py
+++ b/atomac/ldtpd/utils.py
@@ -331,7 +331,7 @@ class Utils(object):
             app_windows=app.windows()
             try:
                 # Tested with
-                # selectmenuitem('appChickenoftheVNC', 'Connection;Open Connection…')
+                # selectmenuitem('appChickenoftheVNC', 'Connection;Open Connection...')
                 if not app_windows and app.AXRole == "AXApplication":
                     # If app doesn't have any windows and its role is AXApplication
                     # add to window list


### PR DESCRIPTION
Fixes:

```
SyntaxError: Non-ASCII character '\xe2' in file .../.env/src/atomac/atomac/ldtpd/utils.py on line 334, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

Happens when you use latest pyatom from sources. Mac OS 10.9.3, iTerm nightly, Python 2.7.5
