### PR TITLE
Issue #99: generatekeyevent should send events to the system.

### DIFF
--- a/atomac/AXClasses.py
+++ b/atomac/AXClasses.py
@@ -250,11 +250,15 @@ class BaseAXUIElement(_a11y.AXUIElement):
          self.keyboard = AXKeyboard.loadKeyboard()
 
       if (keychr in self.keyboard['upperSymbols'] and not modFlags):
-         self._sendKeyWithModifiers(keychr, [AXKeyCodeConstants.SHIFT])
+         self._sendKeyWithModifiers(keychr,
+                                    [AXKeyCodeConstants.SHIFT],
+                                    globally)
          return
 
       if (keychr.isupper() and not modFlags):
-         self._sendKeyWithModifiers(keychr.lower(), [AXKeyCodeConstants.SHIFT])
+         self._sendKeyWithModifiers(keychr.lower(),
+                                    [AXKeyCodeConstants.SHIFT],
+                                    globally)
          return
 
       if (keychr not in self.keyboard):
@@ -888,6 +892,16 @@ class NativeUIElement(BaseAXUIElement):
    def sendKey(self, keychr):
       '''sendKey - send one character with no modifiers'''
       return self._sendKey(keychr)
+
+   def sendGlobalKey(self, keychr):
+      '''Sends one character without modifiers to the system.
+
+         It will not send an event directly to the application, system will
+         dispatch it to the window which has keyboard focus.
+
+         Parameters: keychr - Single keyboard character which will be sent.
+      '''
+      return self._sendKey(keychr, globally=True)
 
    def sendKeys(self, keystr):
       '''sendKeys - send a series of characters with no modifiers'''

--- a/atomac/ldtpd/keypress_actions.py
+++ b/atomac/ldtpd/keypress_actions.py
@@ -21,6 +21,7 @@
 """KeyboardOp class."""
 
 import time
+from atomac.AXClasses import NativeUIElement
 from atomac.AXKeyCodeConstants import *
 from server_exception import LdtpServerException
 
@@ -143,9 +144,18 @@ class KeyboardOp:
     return key_vals
 
 class KeyComboAction:
-    def __init__(self, window, data):
+    """Used for sending keyboard events to the system."""
+
+    def __init__(self, data):
+        """
+        @param data: data to type
+        @type data: string
+        """
         self._data=data
-        self._window=window
+        # Create dummy window, it has code for creating and queuing events.
+        # We will send events 'globally' to the system so dummy window will
+        # not receive the event.
+        self._dummy_window=NativeUIElement()
         _keyOp=KeyboardOp()
         self._keyvalId=_keyOp.get_keyval_id(data)
         if not self._keyvalId:
@@ -155,9 +165,10 @@ class KeyComboAction:
     def _doCombo(self):
         for key_val in self._keyvalId:
             if key_val.modifiers:
-              self._window.sendKeyWithModifiers(key_val.value, key_val.modVal)
+              self._dummy_window.sendGlobalKeyWithModifiers(key_val.value,
+                                                            key_val.modVal)
             else:
-              self._window.sendKey(key_val.value)
+              self._dummy_window.sendGlobalKey(key_val.value)
             time.sleep(0.01)
 
 class KeyPressAction:

--- a/atomac/ldtpd/text.py
+++ b/atomac/ldtpd/text.py
@@ -31,21 +31,13 @@ from server_exception import LdtpServerException
 class Text(Utils):
     def generatekeyevent(self, data):
         """
-        Functionality of generatekeyevent is similar to typekey of 
-        LTFX project.
+        Generates key event to the system, this simulates the best user like
+        interaction via keyboard.
         
         @param data: data to type.
         @type data: string
-
-        @return: 1 on success.
-        @rtype: integer
         """
-        try:
-            window=self._get_front_most_window()
-        except (IndexError, ):
-            window=self._get_any_window()
-        key_combo_action = KeyComboAction(window, data)
-        return 1
+        KeyComboAction(data)
 
     def keypress(self, data):
         """


### PR DESCRIPTION
Sending keyboard events to the system is the best way of simulating user
interaction via keyboard. System is dispatching the evenets to the
focused application.

Sometimes focused application may not be the front most application.
