### PR TITLE
Add back compatibility with 10.9

### DIFF
--- a/atomac/ldtpd/generic.py
+++ b/atomac/ldtpd/generic.py
@@ -25,7 +25,15 @@ import os
 import tempfile
 from base64 import b64encode
 from AppKit import NSPNGFileType, NSMakeRect
-from Quartz.CoreGraphics import CGWindowListCreateImage, CGRectInfinite, CIImage, NSBitmapImageRep
+from Quartz.CoreGraphics import CGWindowListCreateImage, CGRectInfinite
+try:
+    from Quartz.CoreGraphics import CIImage
+except (ImportError):
+    from Quartz import CIImage
+try:
+    from Quartz.CoreGraphics import NSBitmapImageRep
+except (ImportError):
+    from Quartz import NSBitmapImageRep
 from utils import Utils
 from server_exception import LdtpServerException
 

--- a/atomac/ldtpd/mouse.py
+++ b/atomac/ldtpd/mouse.py
@@ -1,3 +1,5 @@
+ # -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 VMware, Inc. All Rights Reserved.
 
 # This file is part of ATOMac.


### PR DESCRIPTION
These two commits add back compatibility with default 10.9.5 python and pyobjc library provided by system

- [x] Add default encoding to mouse.py
- [x] Add fallback on library imports