### PR TITLE
fix getTextValue of TextArea

### DIFF
--- a/atomac/ldtpd/text.py
+++ b/atomac/ldtpd/text.py
@@ -144,8 +144,8 @@ class Text(Utils):
         @rtype: string
         """
         object_handle=self._get_object_handle(window_name, object_name)
-        if not object_handle.AXEnabled:
-            raise LdtpServerException(u"Object %s state disabled" % object_name)
+     #   if not object_handle.AXEnabled:
+     #      raise LdtpServerException(u"Object %s state disabled" % object_name)
         return object_handle.AXValue
 
     def inserttext(self, window_name, object_name, position, data):


### PR DESCRIPTION
while getting text out of TextArea object, there is an exception taking place. it is because textArea doesnt have enabled attribute which atomac is looking for. So modifying that part of code.