### PR TITLE
Create axvalue_to_pytuple to convert AXValueRef to tuples

### DIFF
--- a/atomac/_a11y.py
+++ b/atomac/_a11y.py
@@ -1,13 +1,61 @@
 import objc
+import logging
+import re
 import signal
 import Cocoa
+from collections import namedtuple
 from CoreFoundation import *
 from ApplicationServices import *
 from PyObjCTools import AppHelper, MachSignals
 
+logger = logging.getLogger(__name__)
+
 """
 Library of Apple A11y functions
 """
+def axvalue_to_pytuple(axvalueref):
+    """
+    Original this project was using AXValueGetValue to get the value and
+    create a tuple representation of AXValue.
+
+    pyobjc: "AXValueGetValue is not yet supported"
+    (https://pythonhosted.org/pyobjc/apinotes/ApplicationServices.html)
+
+    Workaround by parsing the string representation of an AXValueRef object
+
+    :param axvalueref: the AXValueRef object from AXUIElementCopyAttributeValue
+    :return: python tuple representation of the axvalue
+    """
+    logger.debug('AXValueRef: %s' % axvalueref)
+    extracted_str = re.search('{(.*)}', str(axvalueref)).group(1)
+
+    # combine '=' with key to help identify a key when tokenizing
+    massaged_str = extracted_str.replace(' =', '=')
+    tokens = massaged_str.split(' ')
+
+    axvalue = dict()
+    current_key = None
+
+    for token in tokens:
+        if token[-1] == '=':
+            current_key = token[:-1]
+            axvalue[current_key] = dict()
+        else:
+            try:
+                key, value = token.split(':')
+                axvalue[current_key][key] = float(value)
+            except ValueError:
+                axvalue[current_key] = token
+
+    AXValueType = namedtuple(
+        typename=axvalue['type'].replace('kAXValue', ''),
+        field_names=axvalue['value'].keys()
+    )
+
+    result = AXValueType(**axvalue['value'])
+
+    logger.debug('AXValue: %s\nPyTuple: %s' % (axvalueref, result))
+    return result
 
 def _CFAttributeToPyObject(self, attrValue):
     def list_helper(list_value):
@@ -46,9 +94,9 @@ def _CFAttributeToPyObject(self, attrValue):
 
     ax_attr_type = AXValueGetType(attrValue)
     ax_type_map = {
-        kAXValueCGSizeType: tuple,
-        kAXValueCGPointType: tuple,
-        kAXValueCFRangeType: tuple,
+        kAXValueCGSizeType: axvalue_to_pytuple,
+        kAXValueCGPointType: axvalue_to_pytuple,
+        kAXValueCFRangeType: axvalue_to_pytuple,
     }
     try:
         return ax_type_map[ax_attr_type](attrValue)


### PR DESCRIPTION
I was looking into issue #162 and discovered some things.

[pyobjc](https://bitbucket.org/ronaldoussoren/pyobjc/) documentation says ["`AXValueGetValue` is not yet supported, it requires a manual wrapper."](https://pythonhosted.org/pyobjc/apinotes/ApplicationServices.html)
This is a problem because `AXValueGetValue` was how the original c-extension of atomac was getting the value.

This PR implements a workaround by parsing the string of AXValueRef object to get the values and return a tuple like it was before.

snippet used in c-extension:
https://github.com/pyatom/pyatom/blob/7a0e8f6f8fb2161f0b50750ccc32ba3700b099ea/atomac/_a11y/conversion.c#L92-L158