### PR TITLE
Notifications

### DIFF
--- a/atomac/AXClasses.py
+++ b/atomac/AXClasses.py
@@ -617,7 +617,8 @@ class BaseAXUIElement(_a11y.AXUIElement):
                 else:
                     callbackKwargs = kwargs
         else:
-            callbackArgs = (retelem, )
+            if retelem:
+                callbackArgs = (retelem, )
             # Pass the kwargs to the default callback
             callbackKwargs = kwargs
 


### PR DESCRIPTION
Fixes #164 
Personally don't use waitFor often.
I wrote this script to test my changes with based on example from #164 .
```
import atomac
bundle = 'com.apple.Safari'
app = atomac.getAppRefByBundleId(bundle)
app.activate()
window = app.windows()[0]
app.waitForFocusedWindowToChange(window.AXTitle)
```

I run the script then manually switched Safari's window to another and back and the script stops waiting. 😄

Interestingly, running the same script with atomac 1.1.0 gives me segfaults. 😮 